### PR TITLE
feat(format-bytes): implement formatBytes utility

### DIFF
--- a/src/__tests__/formatBytes.test.js
+++ b/src/__tests__/formatBytes.test.js
@@ -38,3 +38,14 @@ describe('formatBytes', () => {
   })
 
 })
+
+  // Edge cases from subagent verification
+  test('bytes > PB range clamps to PB', () => {
+    const result = formatBytes(Math.pow(1024, 6))
+    expect(result).toMatch(/PB$/)
+  })
+
+  test('non-number input throws Error', () => {
+    expect(() => formatBytes(null)).toThrow('bytes must be a number')
+    expect(() => formatBytes('1kb')).toThrow('bytes must be a number')
+  })

--- a/src/__tests__/formatBytes.test.js
+++ b/src/__tests__/formatBytes.test.js
@@ -1,0 +1,40 @@
+const { formatBytes } = require('../formatBytes')
+
+describe('formatBytes', () => {
+
+  // R1 + Scenario 1
+  test('formatBytes(0) returns "0 B"', () => {
+    expect(formatBytes(0)).toBe('0 B')
+  })
+
+  // R2 + Scenario 2
+  test('formatBytes(1024) returns "1 KB"', () => {
+    expect(formatBytes(1024)).toBe('1 KB')
+  })
+
+  // R3 + Scenario 3
+  test('formatBytes(1536000) returns "1.46 MB"', () => {
+    expect(formatBytes(1536000)).toBe('1.46 MB')
+  })
+
+  // R3 + Scenario 4 - custom decimals
+  test('formatBytes(1048576, 0) returns "1 MB"', () => {
+    expect(formatBytes(1048576, 0)).toBe('1 MB')
+  })
+
+  // R4 + Scenario 5 - negative decimals guard
+  test('formatBytes(1024, -1) treats decimals as 0', () => {
+    expect(formatBytes(1024, -1)).toBe('1 KB')
+  })
+
+  // R5 + Scenario 6 - negative bytes throws
+  test('formatBytes(-1) throws Error', () => {
+    expect(() => formatBytes(-1)).toThrow('bytes must be non-negative')
+  })
+
+  // R6 - format check: number + space + unit
+  test('returns format with single space separator', () => {
+    expect(formatBytes(1024)).toMatch(/^\d+(\.\d+)? [A-Z]+$/)
+  })
+
+})

--- a/src/formatBytes.js
+++ b/src/formatBytes.js
@@ -1,0 +1,22 @@
+/**
+ * formatBytes — 將 bytes 數字轉成人可讀字串
+ *
+ * @param {number} bytes    - 位元組數，必須 >= 0
+ * @param {number} decimals - 小數位數，預設 2；< 0 自動視為 0
+ * @returns {string}        - 例：'0 B'、'1.46 MB'、'2 GB'
+ * @throws {Error}          - bytes < 0 時拋出 'bytes must be non-negative'
+ */
+function formatBytes(bytes, decimals = 2) {
+  if (bytes < 0) throw new Error('bytes must be non-negative')
+  if (bytes === 0) return '0 B'
+
+  const KILO  = 1024
+  const UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+  const exp   = Math.floor(Math.log(bytes) / Math.log(KILO))
+  const value = bytes / Math.pow(KILO, exp)
+  const dp    = Math.max(0, decimals)
+
+  return `${parseFloat(value.toFixed(dp))} ${UNITS[exp]}`
+}
+
+module.exports = { formatBytes }

--- a/src/formatBytes.js
+++ b/src/formatBytes.js
@@ -4,15 +4,16 @@
  * @param {number} bytes    - 位元組數，必須 >= 0
  * @param {number} decimals - 小數位數，預設 2；< 0 自動視為 0
  * @returns {string}        - 例：'0 B'、'1.46 MB'、'2 GB'
- * @throws {Error}          - bytes < 0 時拋出 'bytes must be non-negative'
+ * @throws {Error}          - bytes < 0 或非數字時拋出
  */
 function formatBytes(bytes, decimals = 2) {
+  if (typeof bytes !== 'number' || isNaN(bytes)) throw new Error('bytes must be a number')
   if (bytes < 0) throw new Error('bytes must be non-negative')
   if (bytes === 0) return '0 B'
 
   const KILO  = 1024
   const UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
-  const exp   = Math.floor(Math.log(bytes) / Math.log(KILO))
+  const exp   = Math.min(Math.floor(Math.log(bytes) / Math.log(KILO)), UNITS.length - 1)
   const value = bytes / Math.pow(KILO, exp)
   const dp    = Math.max(0, decimals)
 


### PR DESCRIPTION
## 目的
實作 `formatBytes(bytes, decimals)` 工具函式，將 bytes 數字轉成人可讀字串（KB/MB/GB 等）。

## 做了什麼
- `src/formatBytes.js` — 新增函式，支援 B/KB/MB/GB/TB/PB，可自訂小數位
- `src/__tests__/formatBytes.test.js` — 9 個測試，覆蓋 R1-R6 + subagent 發現的 edge case

## 驗收條件
- [x] R1: formatBytes(0) === '0 B'
- [x] R2: 1024-base 單位計算
- [x] R3: decimals 參數，預設 2
- [x] R4: decimals < 0 視為 0
- [x] R5: bytes < 0 拋出 Error
- [x] R6: '<數字> <單位>' 格式

## 測試方式
- [x] 9/9 tests passing
- [x] subagent 獨立驗證通過，edge case 已補

Closes #1
Spec: .myspec/active/format-bytes/spec.md
